### PR TITLE
FIX: Represent dates as msec not seconds

### DIFF
--- a/src/transit/Transit.php
+++ b/src/transit/Transit.php
@@ -53,11 +53,11 @@ class Transit {
         $this->registerHandler(new SymbolHandler());
         $this->registerHandler(new SetHandler());
         $this->registerHandler(new ListHandler());
+        $this->registerHandler(new TimestampHandler());
         $this->registerHandler(new DateTimeHandler());
         $this->registerHandler(new URIHandler());
         $this->registerHandler(new UUIDHandler());
         $this->registerHandler(new CharHandler());
-        $this->registerHandler(new TimestampHandler());
         $this->registerHandler(new ArbitraryPrecisionDecimalHandler());
         $this->registerHandler(new ArbitraryPrecisionIntegerHandler());
     }

--- a/src/transit/handlers/DateTimeHandler.php
+++ b/src/transit/handlers/DateTimeHandler.php
@@ -13,11 +13,11 @@ class DateTimeHandler implements Handler {
     }
 
     public function representation($obj) {
-        return $obj->getTimestamp();
+        return $obj->getTimestamp() * 1000;
     }
 
     public function resolve($obj) {
-        return new \DateTime('@' . $obj);
+        return new \DateTime('@' . $obj/1000);
     }
 
 }

--- a/test/test.php
+++ b/test/test.php
@@ -414,8 +414,8 @@ Assert::equal(
 //-------------------------
 // extensions
 
-//Assert::equal('["~m482196050"]', w([new DateTime('1985-04-12T23:20:50.52Z')]));
-//Assert::equal([new DateTime('1985-04-12T23:20:50.52Z')], r('["~m482196050"]'));
+Assert::equal('["~m482196050000"]', w([new DateTime('1985-04-12T23:20:50.52Z')]));
+Assert::equal((new DateTime('1985-04-12T23:20:50.52Z'))->getTimestamp(), r('["~m482196050000"]')[0]->getTimestamp());
 
 Assert::equal('["~bYWJj"]', w([new Bytes('abc')]));
 Assert::equal([new Bytes('abc')], r('["~bYWJj"]'));


### PR DESCRIPTION
The spec at https://github.com/cognitect/transit-format says that points in time should be
represented as "int msecs since 1970". getTimestamp() returns seconds, so we need to
multiply by 1000.